### PR TITLE
correct typo "Fecdra"

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -55,7 +55,7 @@ if [[ ! -f "${HOME}/.disable_blend_msg" ]]; then
 	echo -e "  blend install <PKG>"
 	echo -e "${shell_reset}To remove a package in an Arch container:${shell_bold}"
 	echo -e "  blend remove <PKG>"
-	echo -e "${shell_reset}To install a package in a Fecdra container:${shell_bold}"
+	echo -e "${shell_reset}To install a package in a Fedora container:${shell_bold}"
 	echo -e "  blend install <PKG> -d fedora-rawhide"
 	echo -e "${shell_reset}To enter a Fedora container:${shell_bold}"
 	echo -e "  blend enter -cn fedora-rawhide"


### PR DESCRIPTION
A simple typo fix:

`To install a package in a Fecdra container:
  blend install <PKG> -d fedora-rawhide`
  
  `Fecdra` -> `Fedora`